### PR TITLE
Fix reorder-python-imports application-directories config in .pre-commit-config.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: reorder-python-imports
         name: Reorder Python Imports (src, tests)
-        args: ["--application-directories", ".:avi_edit"]
+        args: ["--application-directories", "."]
 
   - repo: https://github.com/psf/black
     rev: 19.10b0

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: reorder-python-imports
         name: Reorder Python Imports (src, tests)
-        args: ["--application-directories", ".:avi_edit"]
+        args: ["--application-directories", ".:src:tests"]
 
   - repo: https://github.com/psf/black
     rev: 19.10b0


### PR DESCRIPTION
Fix the `application-directories` config used by `reorder-python-imports` in `.pre-commit-config.yml`.