### PR TITLE
Ignore __about__.py when running coverage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project doesn't really have releases so... this is really just the same
 thing as the git commit history.
 
 
+## 2021-07-08
++ Added `__about__.py` to the coverage ignore (#11)
+
+
 ## 2021-06-20
 + Updated `py` version. #9.
 + Update `requests` and `urllib3` used by main project. (#10)

--- a/src/data/reference-proj/setup.cfg
+++ b/src/data/reference-proj/setup.cfg
@@ -27,6 +27,8 @@ addopts = -ra
 
 [coverage:run]
 branch = True
+omit =
+    src/reference_proj/__about__.py
 
 [coverage:html]
 show_contexts = True

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -27,6 +27,8 @@ addopts = -ra
 
 [coverage:run]
 branch = True
+omit =
+    src/{{cookiecutter.package_name}}/__about__.py
 
 [coverage:html]
 show_contexts = True


### PR DESCRIPTION
Ignore __about__.py when running coverage.

Fixes #11 