### PR TITLE
Do not sort JSON keys in the main project.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: requirements-txt-fixer
       - id: check-json
       - id: pretty-format-json
-        args: ["--autofix"]
+        args: ["--autofix", "--no-sort-keys"]
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: fix-encoding-pragma


### PR DESCRIPTION
Do not sort JSON keys in the main project.

Sorting keys will adjust the order in which CookieCutter prompts the user and can lead to confusion.