### PR TITLE
Add --no-version-check CLI arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project doesn't really have releases so... this is really just the same
 thing as the git commit history.
 
 
+## 2022-04-04
++ Added a `--version-check / --no-version-check` arg to the CLI. (#28)
+
+
 ## 2021-09-30
 + Fixed type annotation issues in `setup.py`. (#26)
 

--- a/src/main.py
+++ b/src/main.py
@@ -187,14 +187,21 @@ def _parse_extra_context(ctx, param, value):
     ),
     callback=_parse_extra_context,
 )
-def main(outdir, extra_context):
+@click.option(
+    "--version-check/--no-version-check",
+    is_flag=True,
+    default=True,
+    help="Run a version check against the remote repository.",
+)
+def main(outdir, extra_context, version_check):
     """
     Create a new project in OUTDIR.
 
     Note that OUTDIR should *not* contain the project name - CookieCutter
     will create the project directory automatically.
     """
-    _check_repo()
+    if version_check:
+        _check_repo()
 
     _default_extra_context = {"create_date": datetime.date.today().isoformat()}
     passed_extra_context = _default_extra_context

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -306,6 +306,10 @@ def test_main_github_ci(tmp_path, extra_context):
     assert not (proj_path / ".gitlab_ci.yml").exists()
 
 
+# Yeah, this looks eerily similar to test_main_github_ci, but the difference
+# between github (directory) and gitlab (file), and the fact that we need to
+# assert the **other** doesn't exist, makes combining these two tests into
+# a single parametrized one a bit annoying.
 def test_main_gitlab_ci(tmp_path, extra_context):
     proj_path = tmp_path / extra_context["project_slug"]
 
@@ -319,7 +323,7 @@ def test_main_gitlab_ci(tmp_path, extra_context):
 
     assert result.exit_code == 0
 
-    # The .gitlab-ci.yml directory should exist
+    # The .gitlab-ci.yml file should exist
     fp = proj_path / ".gitlab-ci.yml"
     assert fp.exists()
     assert fp.is_file()

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -253,7 +253,12 @@ def test_fix_timestamp_raises(ts):
 def test_main(tmp_path, extra_context):
     proj_path = tmp_path / extra_context["project_slug"]
 
-    args = [str(tmp_path), "--extra-context", f"""{extra_context}"""]
+    args = [
+        "--no-version-check",
+        str(tmp_path),
+        "--extra-context",
+        f"""{extra_context}""",
+    ]
 
     runner = CliRunner()
     result = runner.invoke(main.main, args)
@@ -271,7 +276,12 @@ def test_main_no_ci(tmp_path, extra_context):
 
     extra_context["create_ci_file"] = "n"
 
-    args = [str(tmp_path), "--extra-context", f"""{extra_context}"""]
+    args = [
+        "--no-version-check",
+        str(tmp_path),
+        "--extra-context",
+        f"""{extra_context}""",
+    ]
 
     runner = CliRunner()
     result = runner.invoke(main.main, args)
@@ -290,7 +300,12 @@ def test_main_github_ci(tmp_path, extra_context):
     extra_context["project_host"] = "GitHub"
     extra_context["create_ci_file"] = "y"
 
-    args = [str(tmp_path), "--extra-context", f"""{extra_context}"""]
+    args = [
+        "--no-version-check",
+        str(tmp_path),
+        "--extra-context",
+        f"""{extra_context}""",
+    ]
 
     runner = CliRunner()
     result = runner.invoke(main.main, args)
@@ -316,7 +331,12 @@ def test_main_gitlab_ci(tmp_path, extra_context):
     extra_context["project_host"] = "GitLab"
     extra_context["create_ci_file"] = "y"
 
-    args = [str(tmp_path), "--extra-context", f"""{extra_context}"""]
+    args = [
+        "--no-version-check",
+        str(tmp_path),
+        "--extra-context",
+        f"""{extra_context}""",
+    ]
 
     runner = CliRunner()
     result = runner.invoke(main.main, args)


### PR DESCRIPTION
This adds a `--no-version-check` CLI arg that will skip the version check.

Fixes #28.