### PR TITLE
Replace git:// with https:// as Github has changed their policies.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: black
         language_version: python3.6
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
       - id: requirements-txt-fixer

--- a/src/data/reference-proj/.pre-commit-config.yaml
+++ b/src/data/reference-proj/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: black
         language_version: python3.6
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
       - id: requirements-txt-fixer

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: black
         language_version: python3.6
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
       - id: requirements-txt-fixer


### PR DESCRIPTION
Replace git:// with https:// as Github has changed their policies.

See https://github.blog/2021-09-01-improving-git-protocol-security-github/