### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project doesn't really have releases so... this is really just the same
 thing as the git commit history.
 
 
-# 2023-10-24
+## 2023-10-24
 + Updated template to use Python 3.10.
 + Updates to CI, both the main project and the template itself.
++ Moved config to pyproject.toml
 
 
 ## 2022-04-04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "_template_python"
+version = "0.0.0"
+description = "My Python project template."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Douglas Thor"},  # so that package core metadata "Author" field gets populated.
+    {name = "Douglas Thor", email = "doug.thor@gmail.com"},
+]
+maintainers = []
+keywords = []
+classifiers = []
+dependencies = [
+    "cookiecutter>=2.1.1<3.0.0",
+]
+
+[project.optional-dependencies]
+
+[project.urls]
+"Source Code" = "https://github.com/dougthor42/_template_python"
+"Changelog" = "https://github.com/dougthor42/_template_python/blob/master/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/dougthor42/_template_python/issues"
+
+[tool.flake8]
+max-line-length = 88
+ignore = W503, E203, E266
+# W503: line breaks before binary operator. Not pep8-compliant
+# E203: whitespace before ':'. Not pep8-compliant
+# E266: Too many leading '#' before comment
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = [
+    "src",
+]
+# Our golden master directory structure has tests in it, and we don't want
+# pytest to discover those (which ends up making a __pycache__ dir and mucking
+# things up)
+norecursedirs = [
+    "data/reference-proj",
+]
+
+[tool.coverage.run]
+branch = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "_template_python"
+name = "template_python"
 version = "0.0.0"
 description = "My Python project template."
 readme = "README.md"
@@ -17,7 +17,7 @@ maintainers = []
 keywords = []
 classifiers = []
 dependencies = [
-    "cookiecutter>=2.1.1<3.0.0",
+    "cookiecutter>=2.1.1,<3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -40,4 +40,4 @@ norecursedirs = [
 ]
 
 [tool.coverage.run]
-branch = True
+branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,6 @@ dependencies = [
 "Changelog" = "https://github.com/dougthor42/_template_python/blob/master/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/dougthor42/_template_python/issues"
 
-[tool.flake8]
-max-line-length = 88
-ignore = W503, E203, E266
-# W503: line breaks before binary operator. Not pep8-compliant
-# E203: whitespace before ':'. Not pep8-compliant
-# E266: Too many leading '#' before comment
-
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,3 @@ ignore = W503, E203, E266
 # W503: line breaks before binary operator. Not pep8-compliant
 # E203: whitespace before ':'. Not pep8-compliant
 # E266: Too many leading '#' before comment
-
-[tool:pytest]
-addopts = -ra
-testpaths = src
-# Our golden master directory structure has tests in it, and we don't want
-# pytest to discover those (which ends up making a __pycache__ dir and mucking
-# things up)
-norecursedirs = data/reference-proj
-
-[coverage:run]
-branch = True


### PR DESCRIPTION
Switch to `pyproject.toml`

We can't fully remove `setup.cfg` because flake8 doesn't support it, but I plan on removing flake8 soon (replacing with `ruff`)